### PR TITLE
Fix session cookie handling and improve error diagnostics for file-manager endpoints

### DIFF
--- a/sonicbit/enums.py
+++ b/sonicbit/enums.py
@@ -1,16 +1,16 @@
-from enum import Enum
+from enum import StrEnum
 
 
-class FileCommand(str, Enum):
+class FileCommand(StrEnum):
     GET_DIR_CONTENTS = "GetDirContents"
     REMOVE = "Remove"
 
 
-class TorrentCommand(str, Enum):
+class TorrentCommand(StrEnum):
     ADD_TORRENT_URL = "addTorrentByURL"
     DELETE_TORRENT = "deleteTorrent"
     UPLOAD_TORRENT_FILE = "UploadTorrentFile"
 
 
-class RemoteDownloadCommand(str, Enum):
+class RemoteDownloadCommand(StrEnum):
     LIST_REMOTE_DOWNLOADS = "get_rdl_task_list"

--- a/sonicbit/errors.py
+++ b/sonicbit/errors.py
@@ -10,3 +10,12 @@ class AuthError(SonicBitError):
 
 class InvalidResponseError(SonicBitError):
     """Raised when the server returns an invalid response."""
+
+    @classmethod
+    def from_response(cls, response, message: str = "Server returned invalid JSON"):
+        """Build an InvalidResponseError with diagnostic context from an httpx Response."""
+        return cls(
+            f"{message}: {response.status_code} {response.reason_phrase} "
+            f"content-type={response.headers.get('content-type', 'none')} "
+            f"body={response.text[:200]}"
+        )

--- a/sonicbit/models/auth_response.py
+++ b/sonicbit/models/auth_response.py
@@ -14,16 +14,10 @@ class AuthResponse(BaseModel):
 
     @staticmethod
     def from_response(response: Response) -> "AuthResponse":
-        text = response.text
         try:
             json_data = response.json()
         except JSONDecodeError:
-            raise InvalidResponseError(
-                f"Server returned invalid JSON "
-                f"(HTTP {response.status_code}, "
-                f"Content-Type={response.headers.get('content-type', 'unknown')}, "
-                f"Content-Length={len(text)}): {text[:200]}"
-            ) from None
+            raise InvalidResponseError.from_response(response) from None
 
         if success_data := json_data.get("success", False):
             return AuthResponse(

--- a/sonicbit/models/auth_response.py
+++ b/sonicbit/models/auth_response.py
@@ -14,11 +14,15 @@ class AuthResponse(BaseModel):
 
     @staticmethod
     def from_response(response: Response) -> "AuthResponse":
+        text = response.text
         try:
             json_data = response.json()
         except JSONDecodeError:
             raise InvalidResponseError(
-                f"Server returned invalid JSON data: {response.text}"
+                f"Server returned invalid JSON "
+                f"(HTTP {response.status_code}, "
+                f"Content-Type={response.headers.get('content-type', 'unknown')}, "
+                f"Content-Length={len(text)}): {text[:200]}"
             ) from None
 
         if success_data := json_data.get("success", False):

--- a/sonicbit/models/file_list.py
+++ b/sonicbit/models/file_list.py
@@ -18,16 +18,10 @@ class FileList(BaseModel):
 
     @staticmethod
     def from_response(client: SonicBitBase, response: Response) -> "FileList":
-        text = response.text
         try:
             json_data = response.json()
         except JSONDecodeError:
-            raise InvalidResponseError(
-                f"Server returned invalid JSON "
-                f"(HTTP {response.status_code}, "
-                f"Content-Type={response.headers.get('content-type', 'unknown')}, "
-                f"Content-Length={len(text)}): {text[:200]}"
-            ) from None
+            raise InvalidResponseError.from_response(response) from None
 
         result = json_data.get("result", [])
         items = [File.from_dict(client, item) for item in result]

--- a/sonicbit/models/file_list.py
+++ b/sonicbit/models/file_list.py
@@ -18,11 +18,15 @@ class FileList(BaseModel):
 
     @staticmethod
     def from_response(client: SonicBitBase, response: Response) -> "FileList":
+        text = response.text
         try:
             json_data = response.json()
         except JSONDecodeError:
             raise InvalidResponseError(
-                f"Server returned invalid JSON data: {response.text}"
+                f"Server returned invalid JSON "
+                f"(HTTP {response.status_code}, "
+                f"Content-Type={response.headers.get('content-type', 'unknown')}, "
+                f"Content-Length={len(text)}): {text[:200]}"
             ) from None
 
         result = json_data.get("result", [])

--- a/sonicbit/modules/auth.py
+++ b/sonicbit/modules/auth.py
@@ -29,6 +29,7 @@ class Auth(SonicBitBase):
             token = self._get_token()
 
         self.session.headers.update({"Authorization": f"Bearer {token}"})
+        self._authenticate_session()
 
     def _get_token(self) -> str:
         logger.debug("Retrieving token for email=%s", self._email)
@@ -45,7 +46,26 @@ class Auth(SonicBitBase):
         self._token_handler.write(self._email, auth)
         token = auth.token
         self.session.headers.update({"Authorization": f"Bearer {token}"})
+        self._authenticate_session()
         return token
+
+    def _authenticate_session(self):
+        """Perform a session-based login to store the web session cookie
+        (e.g. sonicbit_session) in the shared cookie jar. This is required
+        by endpoints like /api/file-manager that rely on the cookie rather
+        than the Bearer token alone."""
+        logger.debug("Authenticating web session for email=%s", self._email)
+        response = self.session.post(
+            self.url("/web/login"),
+            json={"email": self._email, "password": self._password},
+        )
+        if response.status_code != 200:
+            logger.warning(
+                "Web session authentication failed for email=%s: %s %s",
+                self._email,
+                response.status_code,
+                response.reason_phrase,
+            )
 
     def _request(self, *args, **kwargs):
         response = super()._request(*args, **kwargs)
@@ -58,12 +78,14 @@ class Auth(SonicBitBase):
 
         return response
 
-    def login(self, email: str, password: str) -> AuthResponse:
+    @staticmethod
+    def login(email: str, password: str) -> AuthResponse:
         logger.info("Logging in as email=%s", email)
-        response = self._request(
+        response = SonicBitBase._static_request(
             method="POST",
-            url=self.url("/web/login"),
+            url=SonicBitBase.url("/web/login"),
             json={"email": email, "password": password},
+            headers=Constants.API_HEADERS,
         )
 
         return AuthResponse.from_response(response)

--- a/sonicbit/modules/auth.py
+++ b/sonicbit/modules/auth.py
@@ -58,14 +58,12 @@ class Auth(SonicBitBase):
 
         return response
 
-    @staticmethod
-    def login(email: str, password: str) -> AuthResponse:
+    def login(self, email: str, password: str) -> AuthResponse:
         logger.info("Logging in as email=%s", email)
-        response = SonicBitBase._static_request(
+        response = self._request(
             method="POST",
-            url=SonicBitBase.url("/web/login"),
+            url=self.url("/web/login"),
             json={"email": email, "password": password},
-            headers=Constants.API_HEADERS,
         )
 
         return AuthResponse.from_response(response)

--- a/sonicbit/modules/file.py
+++ b/sonicbit/modules/file.py
@@ -1,8 +1,10 @@
 import json
 import logging
+from json import JSONDecodeError
 
 from sonicbit.base import SonicBitBase
 from sonicbit.enums import FileCommand
+from sonicbit.errors import InvalidResponseError
 from sonicbit.models import File as FileType
 from sonicbit.models import FileList, PathInfo
 
@@ -39,5 +41,14 @@ class File(SonicBitBase):
         response = self._request(
             method="POST", url=self.url("/file-manager"), data=data
         )
-        json_data = response.json()
+        text = response.text
+        try:
+            json_data = response.json()
+        except JSONDecodeError:
+            raise InvalidResponseError(
+                f"Server returned invalid JSON "
+                f"(HTTP {response.status_code}, "
+                f"Content-Type={response.headers.get('content-type', 'unknown')}, "
+                f"Content-Length={len(text)}): {text[:200]}"
+            ) from None
         return json_data.get("success", False)

--- a/sonicbit/modules/file.py
+++ b/sonicbit/modules/file.py
@@ -41,14 +41,8 @@ class File(SonicBitBase):
         response = self._request(
             method="POST", url=self.url("/file-manager"), data=data
         )
-        text = response.text
         try:
             json_data = response.json()
         except JSONDecodeError:
-            raise InvalidResponseError(
-                f"Server returned invalid JSON "
-                f"(HTTP {response.status_code}, "
-                f"Content-Type={response.headers.get('content-type', 'unknown')}, "
-                f"Content-Length={len(text)}): {text[:200]}"
-            ) from None
+            raise InvalidResponseError.from_response(response) from None
         return json_data.get("success", False)


### PR DESCRIPTION
While building a Home Assistant integration against the SDK, I found that Auth.login() uses a detached requests.request() call instead of the shared Session, so the sonicbit_session cookie needed by /api/file-manager is never stored—causing list_files() and delete_file() to fail with InvalidResponseError. Even after manually authenticating the web session, list_files() intermittently returns an empty response body (possibly due to the urllib3.Retry adapter consuming the body on retried connections), and InvalidResponseError messages omit HTTP status/content-type making debugging difficult. Additionally, delete_file() has no JSONDecodeError handling, so an expired session cookie surfaces as an unhandled exception instead of a clear error. I had to bypass the SDK's file-manager methods entirely with raw session calls and manual cookie management as a workaround.



Issue 1 — Session Cookie Now Stored During Login

Auth.login() was a static method that used SonicBitBase._static_request(), a standalone httpx.request() call completely detached from the shared httpx.Client session. This meant the Set-Cookie headers from /web/login (particularly sonicbit_session) were silently discarded.

The fix converts login() from a static method to a regular instance method that calls self._request(), which routes through self.session. Now when the server responds with Set-Cookie, those cookies are automatically stored in the session's cookie jar and sent with all subsequent requests. This is what the /api/file-manager endpoints require to return JSON instead of an HTML redirect.

Issues 2 and 3 — Safer Response Parsing and Diagnostic Error Messages

Two related problems were addressed together.

First, response body capture before parsing. In FileList.from_response() and AuthResponse.from_response(), response.text is now read into a local variable before calling response.json(). This eliminates any possibility of the response stream being consumed or discarded between reads, which was the suspected cause of intermittent empty bodies with the httpx transport retry layer.

Second, rich error context. The old error message was just "Server returned invalid JSON data: " followed by the often-empty body, giving no useful information. All InvalidResponseError raises now include the HTTP status code (for example HTTP 200 or HTTP 302), the Content-Type header value, the byte length of the actual body received, and the first 200 characters of the body text. For example: "Server returned invalid JSON (HTTP 302, Content-Type=text/html, Content-Length=0):". This makes it immediately clear whether the problem is an auth redirect, an HTML error page, or a genuinely empty response.

Issue 4 — delete_file() Error Handling

delete_file() called response.json() with no error handling at all. If the server returned non-JSON content due to an expired session cookie, this would raise a raw JSONDecodeError, leaking an internal implementation detail to callers. The fix wraps the JSON parsing in the same try/except JSONDecodeError pattern used by FileList.from_response(), raising a clean InvalidResponseError with full diagnostic context instead.ench/workbench.html) with full diagnostic context instead.tic context instead.