### PR TITLE
Fixes

### DIFF
--- a/sonicbit/models/torrent/torrent_info.py
+++ b/sonicbit/models/torrent/torrent_info.py
@@ -4,8 +4,8 @@ from pydantic import BaseModel, Field
 
 
 class TorrentInfo(BaseModel):
-    download_rate: int
-    upload_rate: str
+    download_rate: float
+    upload_rate: float
     size_byte_total: int
     size_byte_limit: int
     percent: float

--- a/sonicbit/models/torrent/torrent_list.py
+++ b/sonicbit/models/torrent/torrent_list.py
@@ -42,7 +42,7 @@ class TorrentList(BaseModel):
                     hash=torrent_data["hash"],
                     size=int(torrent_data["sizeBytes"]),
                     progress=int(torrent_data["percentComplete"]),
-                    download_rate_value=torrent_data["dlRateValue"],
+                    download_rate_value=float(torrent_data["dlRateValue"]),
                     download_rate_unit=torrent_data["dlRateUnit"],
                     upload_rate_value=(
                         torrent_data["upRateValue"]
@@ -67,8 +67,8 @@ class TorrentList(BaseModel):
             torrents = {}
 
         info = TorrentInfo(
-            download_rate=int(info_data["downloadRate"]),
-            upload_rate=info_data["uploadRate"],
+            download_rate=float(info_data["downloadRate"]),
+            upload_rate=float(info_data["uploadRate"]),
             size_byte_total=int(info_data["sizeByteTotal"]),
             size_byte_limit=int(info_data["sizeByteLimit"]),
             percent=float(info_data["percent"]),

--- a/sonicbit/modules/torrent.py
+++ b/sonicbit/modules/torrent.py
@@ -120,16 +120,16 @@ class Torrent(SonicBitBase):
         return TorrentDetails.from_response(response)
 
     def delete_torrent(
-        self, hash: str | List[str], with_file: bool = False
+        self, _hash: str | List[str], with_file: bool = False
     ) -> List[str]:
-        logger.debug("Deleting torrent hash=%s with_file=%s", hash, with_file)
+        logger.debug("Deleting torrent hash=%s with_file=%s", _hash, with_file)
 
-        if isinstance(hash, str):
-            hash = [hash]
+        if isinstance(_hash, str):
+            _hash = [_hash]
 
         params = {
             "command": TorrentCommand.DELETE_TORRENT,
-            "hash_list[]": hash,
+            "hash_list[]": _hash,
             "with_file": 1 if with_file else 0,
         }
         params.update(self.get_time_params())

--- a/sonicbit/modules/torrent.py
+++ b/sonicbit/modules/torrent.py
@@ -44,12 +44,11 @@ class Torrent(SonicBitBase):
             ) from None
 
         added_torrents = []
-        if json_data["success"]:
-            for index in json_data["added"]:
-                added_torrents.append(uri[index])
+        for index in json_data["added"]:
+            added_torrents.append(uri[index])
 
-        if len(added_torrents) == 0:
-            raise SonicBitError("Failed to add torrent")
+        if len(added_torrents) == 0 and not bool(json_data["success"]):
+            raise SonicBitError(f"Failed to add torrent: {json_data}")
 
         return added_torrents
 
@@ -95,6 +94,8 @@ class Torrent(SonicBitBase):
 
         if not json_data["success"]:
             raise SonicBitError("Failed to add torrent: {}".format(json_data["msg"]))
+
+        logger.debug(f"Torrent file uploaded successfully: {json_data}")
 
         return True
 


### PR DESCRIPTION
Hello,

the list_torrents function would sometimes fail due to validation errors (for some reason, it isn't always a string or an int as expected), so I've changed it to cast everything to a float (since that is what the API gives us).

I have also changed the logic of how add_torrent determines a failure. Before it failed when there were zero torrents added and json_data["success"] from the API was true. However, this raises an exception also when I try to add only torrents that are already in the list. Now it only raises the exception if nothing was added and json_data["success"] is False.

I've also added a debug message and renamed a variable where PyCharm was complaining about shadowing a function name :)